### PR TITLE
Search for title of movie and not filename

### DIFF
--- a/service.py
+++ b/service.py
@@ -353,7 +353,7 @@ def Search(item):
                     searchstring = title[-1]
                     #log(u"TITLE NULL Searchstring string = %s" % (searchstring,))
                 else:
-                    searchstring = filename
+                    searchstring = title
                     #log(u"TITLE Searchstring string = %s" % (searchstring,))
 
     PT_ON = __addon__.getSetting( 'PT' )


### PR DESCRIPTION
Many times, my filenames aren't complete, but title in library is correct.
This way it finds subtitles without to use manual search.
