### PR TITLE
Melhoria na pesquisa de streams

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -16,8 +16,11 @@
     <string id="32013">Off</string>
     <string id="32014">Language Settings</string>
     <string id="32015">Advanced Settings</string>
-    <string id="32016">Username is required! Check add-on setttings!</string>
-    <string id="32017">Password is required! Check add-on setttings!</string>
+    <string id="32016">Username is required! Check add-on settings!</string>
+    <string id="32017">Password is required! Check add-on settings!</string>
     <string id="32018">Username and Password is required! Check add-on setttings!</string>
     <string id="32019">Only for registered users! Wrong username and/or password? Check add-on settings. Thanks.</string>
+    <string id="32020">Priority Search by</string>
+    <string id="32021">Filename</string>
+    <string id="32022">Title</string>
 </strings>

--- a/resources/language/Portuguese (Brazil)/strings.xml
+++ b/resources/language/Portuguese (Brazil)/strings.xml
@@ -20,4 +20,7 @@
     <string id="32017">A senha é obrigatória! Verifique as definições do serviço!</string>
     <string id="32018">O usuario e senha são obrigatórios! Verifique as definições do serviço!</string>
     <string id="32019">Apenas para usuarios registados! Usuario e/ou Senha errados? Verifique as definições do serviço!. Obrigado.</string>
+    <string id="32020">Prioridade de Pesquisa por</string>
+    <string id="32021">Nome do Ficheiro</string>
+    <string id="32022">Título</string>		
 </strings>

--- a/resources/language/Portuguese/strings.xml
+++ b/resources/language/Portuguese/strings.xml
@@ -20,4 +20,7 @@
     <string id="32017">A palavra-passe é obrigatória! Verifique as definições do serviço!</string>
     <string id="32018">O utilizador e palavra-passe são obrigatórios! Verifique as definições do serviço!</string>
     <string id="32019">Apenas para utilizadores registados! Utilizador e/ou Palavra-passe errados? Verifique as definições do serviço!. Obrigado.</string>
+    <string id="32020">Prioridade de Pesquisa por</string>
+    <string id="32021">Nome do Ficheiro</string>
+    <string id="32022">Título</string>	
 </strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,5 +13,6 @@
     <category label="32015">
       <setting id="DESC" type="bool" label="32008" default="false"/>
       <setting id="PARENT" type="enum" lvalues="32011|32013" label="32010" default="0"/>
+      <setting id="SEARCH" type="enum" lvalues="32021|32022" label="32020" default="0"/>	  
     </category>   
 </settings>

--- a/service.py
+++ b/service.py
@@ -41,6 +41,7 @@ __temp__       = xbmc.translatePath(pjoin(__profile__, 'temp'))
 sys.path.append (__resource__)
 
 __descon__ = __addon__.getSetting( 'DESC' )
+__search__ = __addon__.getSetting( 'SEARCH' )
 
 main_url = "http://www.legendasdivx.com/"
 debug_pretext = "LegendasDivx"
@@ -375,13 +376,22 @@ def Search(item):
                     searchstring = title[-1]
                     #log(u"TITLE NULL Searchstring string = %s" % (searchstring,))
                 else:
-                    if re.search("(.+?s[0-9][0-9]e[0-9][0-9])", filename, re.IGNORECASE):
-                        searchstring = re.search("(.+?s[0-9][0-9]e[0-9][0-9])", filename, re.IGNORECASE)
-                        searchstring = searchstring.group(0)
-                        #log(u"FilenameTV Searchstring = %s" % (searchstring,))
+                    if __search__ == '0':
+						if re.search("(.+?s[0-9][0-9]e[0-9][0-9])", filename, re.IGNORECASE):
+							searchstring = re.search("(.+?s[0-9][0-9]e[0-9][0-9])", filename, re.IGNORECASE)
+							searchstring = searchstring.group(0)
+							#log(u"FilenameTV Searchstring = %s" % (searchstring,))
+						else:
+							searchstring = filename
+							#log(u"Filename Searchstring = %s" % (searchstring,))
                     else:
-                        searchstring = filename
-                        #log(u"Filename Searchstring = %s" % (searchstring,))
+						if re.search("(.+?s[0-9][0-9]e[0-9][0-9])", title, re.IGNORECASE):
+							searchstring = re.search("(.+?s[0-9][0-9]e[0-9][0-9])", title, re.IGNORECASE)
+							searchstring = searchstring.group(0)
+							#log(u"TitleTV Searchstring = %s" % (searchstring,))
+						else:
+							searchstring = title
+							#log(u"Title Searchstring = %s" % (searchstring,))
 
     PT_ON = __addon__.getSetting( 'PT' )
     PTBR_ON = __addon__.getSetting( 'PTBR' )


### PR DESCRIPTION
Com esta nova opção o utilizador pode escolher se pretende pesquisar pelo nome do ficheiro, e a pesquisa fica mais precisa quando o ficheiro tem a versão no nome (DVDrip, etc). Ou pesquisar pelo titulo do filme, opção mais acertada quando se pesquisa as legendas em streams.

Highlandr, caso aproves esta alteração, aplicas aos teus outros addons, ou queres que faça eu o pull e aplicas?
