### PR TITLE
Fixed search when there is no OriginalTitle

### DIFF
--- a/service.py
+++ b/service.py
@@ -535,6 +535,10 @@ if params['action'] == 'search' or params['action'] == 'manualsearch':
     item['mansearch'] = False
     item['languages'] = []
 
+    if not item['title']:
+        log("VideoPlayer.OriginalTitle is not available, using VideoPlayer.Title instead.")
+        item['title'] = normalizeString(xbmc.getInfoLabel("VideoPlayer.Title"))
+
     if 'searchstring' in params:
         item['mansearch'] = True
         item['mansearchstr'] = urllib.unquote(params['searchstring']).decode('utf-8')


### PR DESCRIPTION
When watching streams, for example, there are times when the VideoPlayer.OriginalTitle is not available. 
Instead of immediately falling back to the filename, which in case of streams is the url of the stream, attempt to use VideoPlayer.Title. 
